### PR TITLE
error in line 152

### DIFF
--- a/13-full-stack/99-reuse/02-spring-security-jwt.md
+++ b/13-full-stack/99-reuse/02-spring-security-jwt.md
@@ -149,7 +149,7 @@ public class JwtSecurityConfig {
         // https://github.com/spring-projects/spring-security/issues/12310
         return httpSecurity
                 .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/authenticate").permitAll()
+                    .requestMatchers("/authenticate").permitAll() //this line return compile error :   reason: varargs mismatch; java.lang.String cannot be converted to org.springframework.security.web.util.matcher.RequestMatcher
                     .requestMatchers(PathRequest.toH2Console()).permitAll() // h2-console is a servlet and NOT recommended for a production
                     .requestMatchers(HttpMethod.OPTIONS,"/**")
                     .permitAll()


### PR DESCRIPTION
Problem:  the requestMatchers(String) method is not available in the version of Spring Security 6+. Starting with Spring Security 6, the requestMatchers method has been updated to be more type-safe and flexible

any advice Please?